### PR TITLE
Add automations feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ todo.txt
 
 .DS_Store
 
-handymkv
+# handymkv
 CLAUDE.MD

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MAIN_PATH=./cmd/handymkv
 
 # Version from git tag (strips leading 'v')
 VERSION=$(shell git describe --tags --always 2>/dev/null | sed 's/^v//')
-LDFLAGS=-ldflags="-X main.applicationVersion=$(VERSION)"
+LDFLAGS=-ldflags="-s -w -X main.applicationVersion=$(VERSION)"
 
 # Detect current OS and architecture
 CURRENT_OS=$(shell go env GOOS)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ As I developed HandyMKV, I found that I was able to add features that I found us
 - Summary of space saved and time elapsed
 - Automated cleanup of raw unencoded files
 - Run history — browse and inspect past ripping/encoding sessions
+- Automations — run custom scripts after encoding with parameters sourced from run data, environment variables, or user prompts
 - Parsing of `HandBrakeCLI` and `makemkvcon` output to provide a more user-friendly experience
 
 ## Objectives
@@ -78,17 +79,25 @@ HandyMKV has a number of command line options and subcommands that can be used t
 
 ```shell
 Usage of handymkv:
-  -c    Configure. Runs the configuration wizard.
+  -a string
+        Automations. A comma delimited list of automation names to run after encoding.
+        Example: -a move-to-plex,notify-discord
   -d string
         Discs. A comma delimited list of disc indexes to rip. Example: -d 0,1,2 (default "0")
-  -l    List. Lists the available discs. The disc index is required to rip a disc. Drives without a valid disc inserted will not be listed.
-  -r    Read. Reads and outputs the first encountered configuration file. The current working directory is searched first, then the user-level configuration.
   -v    Version. Prints the version of the application.
 
 Subcommands:
-  history             Show a summary list of past runs.
-  history <number>    Show details for a specific past run.
-  history clear       Delete all manifest files from the run history directory.
+  config                Show the current configuration.
+  config setup          Run the configuration wizard.
+  config edit           Open the config file in the default editor.
+  discs                 List available discs.
+  history               Show a summary list of past runs.
+  history <number>      Show details for a specific past run.
+  history clear         Delete all manifest files from the run history directory.
+  automations           List all saved automations.
+  automations create    Create a new automation.
+  automations show <name>   Show details of an automation.
+  automations delete <name> Delete an automation.
 ```
 
 ## Installation
@@ -189,7 +198,7 @@ GOOS=linux GOARCH=amd64 go build -o bin/linux-amd64/handymkv ./cmd/handymkv
 The first step is to create a configuration file. This can be done by running the following command:
 
 ```shell
-handymkv -c
+handymkv config setup
 ```
 
 This will start the configuration wizard. It will prompt you for encode settings and various operational settings. Once saved, the configuration will be stored in a file called `config.json`. The location of that file depends on whether user-wide or directory-wide configuration is used.
@@ -240,11 +249,104 @@ By default, manifest files are stored alongside the main configuration:
 - Unix: `~/.config/handymkv/manifests/`
 - Windows: `%APPDATA%\handymkv\manifests\`
 
-A custom directory can be set during the configuration wizard (`handymkv -c`), or by setting `manifest_directory` in `config.json`.
+A custom directory can be set during the configuration wizard (`handymkv config setup`), or by setting `manifest_directory` in `config.json`.
 
 ### Disabling Run History
 
 Run history can be disabled entirely via the configuration wizard or by setting `"disable_manifests": true` in `config.json`. When disabled, `handymkv history` and `handymkv history clear` will display an informational message rather than attempting to read or modify manifest files.
+
+## Automations
+
+Automations let you run local scripts or commands after HandyMKV finishes encoding. Each automation is a standalone configuration that defines a command to run and the parameters it needs. Parameters can be sourced from different places: prompted at runtime, hardcoded static defaults, or populated automatically from HandyMKV run data.
+
+Scripts receive their parameters as environment variables with the prefix `HMKV_PARAM_`. For example, a parameter named `destination_dir` becomes `HMKV_PARAM_DESTINATION_DIR`.
+
+### Managing Automations
+
+```shell
+handymkv automations              # List all saved automations
+handymkv automations create       # Create a new automation (interactive wizard)
+handymkv automations show <name>  # Show details of an automation
+handymkv automations delete <name># Delete an automation
+```
+
+Automation files are stored as JSON in:
+- Unix: `~/.config/handymkv/automations/`
+- Windows: `%APPDATA%\handymkv\automations\`
+
+> **Unix note:** Scripts must be executable before HandyMKV can run them. Make sure to run `chmod +x /path/to/your/script.sh` after creating the script.
+
+### Running Automations
+
+Automations can be selected in two ways:
+
+1. **Interactive prompt** -- if you have automations configured, HandyMKV will ask which ones to run during the normal execution flow.
+2. **CLI flag** -- use `-a` to pre-select automations by name: `handymkv -a move-to-plex,notify-discord`
+
+If no automations exist, no prompt is shown.
+
+### Parameter Sources
+
+When creating an automation, each parameter has a **source** that determines how its value is obtained:
+
+| Source | Description |
+|--------|-------------|
+| `prompt` | Asks the user for a value before the run starts (supports an optional default) |
+| `static` | Uses a hardcoded value — never prompts the user |
+| `hmkv_output` | Populated automatically from HandyMKV run data after encoding completes |
+
+Scripts inherit the full OS environment, so they can read environment variables (like API keys or webhook URLs) directly without needing a dedicated parameter.
+
+### `hmkv_output` Keys
+
+| Key | Value |
+|-----|-------|
+| `hb_output_dir` | Absolute path to the HandBrake output directory for this run |
+| `mkv_output_dir` | Absolute path to the raw MKV output directory for this run |
+| `run_duration` | Duration string, e.g. `12m34s` |
+| `title_count` | Number of titles processed (integer string) |
+| `raw_files_deleted` | `"true"` or `"false"` |
+| `total_raw_size` | Total size of raw MKV files in bytes (integer string) |
+| `total_encoded_size` | Total size of encoded output files in bytes (integer string) |
+
+> **Note:** Automations run *before* raw MKV files are deleted. If your script needs to act on the raw files (e.g. inspect or move them), it will have access to them via `mkv_output_dir`.
+
+### Example: Move Encoded Files to Plex
+
+Create a script `move-to-plex.sh`:
+
+```bash
+#!/bin/bash
+echo "Moving files from $HMKV_PARAM_ENCODED_DIR to $HMKV_PARAM_DESTINATION_DIR"
+mv "$HMKV_PARAM_ENCODED_DIR"/* "$HMKV_PARAM_DESTINATION_DIR/"
+echo "Done."
+```
+
+Then create the automation:
+
+```shell
+handymkv automations create
+```
+
+Configure it with:
+- **Name**: `move-to-plex`
+- **Command**: `/path/to/move-to-plex.sh`
+- **Param 1**: `destination_dir` (source: `prompt`, default: `/mnt/media/plex/movies`)
+- **Param 2**: `encoded_dir` (source: `hmkv_output`, key: `hb_output_dir`)
+
+### Error Handling
+
+If an automation script fails (non-zero exit code), HandyMKV prints a warning and continues with the next automation. Script failures never abort the pipeline.
+
+```
+Running automations...
+  move-to-plex: OK
+  notify-discord: FAILED (exit code 1)
+```
+
+### Example Scripts
+
+An example automation script is available in the repository under [`examples/automations/`](examples/automations/). It demonstrates all three parameter source types: `hmkv_output` (encoded output directory), `prompt` (destination media directory), and `static` (group name to assign to files).
 
 ## Multi-Disc Support
 
@@ -254,7 +356,7 @@ During such multi-disc runs the output files will be sorted into subdirectories 
 
 To rip and encode multiple discs, simply provide a comma delimited list of disc indexes to the `-d` flag. Example: `handymkv -d 0,1,2`.
 
-To see a list of available discs, use the `-l` flag. Example: `handymkv -l`.
+To see a list of available discs, use the `discs` subcommand. Example: `handymkv discs`.
 
 ## A Note on Concurrency
 

--- a/README.md
+++ b/README.md
@@ -278,12 +278,9 @@ Automation files are stored as JSON in:
 
 ### Running Automations
 
-Automations can be selected in two ways:
+Use the `-a` flag to specify automations by name: `handymkv -a move-to-plex,notify-discord`
 
-1. **Interactive prompt** -- if you have automations configured, HandyMKV will ask which ones to run during the normal execution flow.
-2. **CLI flag** -- use `-a` to pre-select automations by name: `handymkv -a move-to-plex,notify-discord`
-
-If no automations exist, no prompt is shown.
+Automations run after encoding completes. If the same name is provided more than once, it will only run once.
 
 ### Parameter Sources
 
@@ -311,28 +308,22 @@ Scripts inherit the full OS environment, so they can read environment variables 
 
 > **Note:** Automations run *before* raw MKV files are deleted. If your script needs to act on the raw files (e.g. inspect or move them), it will have access to them via `mkv_output_dir`.
 
-### Example: Move Encoded Files to Plex
+### Example: Move Encoded Files to a Media Directory
 
-Create a script `move-to-plex.sh`:
-
-```bash
-#!/bin/bash
-echo "Moving files from $HMKV_PARAM_ENCODED_DIR to $HMKV_PARAM_DESTINATION_DIR"
-mv "$HMKV_PARAM_ENCODED_DIR"/* "$HMKV_PARAM_DESTINATION_DIR/"
-echo "Done."
-```
-
-Then create the automation:
+Create an automation using the included example script:
 
 ```shell
 handymkv automations create
 ```
 
 Configure it with:
-- **Name**: `move-to-plex`
-- **Command**: `/path/to/move-to-plex.sh`
-- **Param 1**: `destination_dir` (source: `prompt`, default: `/mnt/media/plex/movies`)
-- **Param 2**: `encoded_dir` (source: `hmkv_output`, key: `hb_output_dir`)
+- **Name**: `move-media`
+- **Command**: `/path/to/examples/automations/move-media.sh`
+- **Param 1**: `encoded_dir` (source: `hmkv_output`, key: `hb_output_dir`)
+- **Param 2**: `media_dir` (source: `prompt`)
+- **Param 3**: `group_name` (source: `static`, value: `media` or your group name)
+
+The script strips the trailing `_t##` identifier MakeMKV appends to filenames (e.g. `My_Movie_t00.mkv` → `My_Movie.mkv`), sets group ownership and permissions, then moves files to the destination directory.
 
 ### Error Handling
 
@@ -344,9 +335,11 @@ Running automations...
   notify-discord: FAILED (exit code 1)
 ```
 
+Exit codes are recorded in the run manifest and are visible when inspecting history with `handymkv history <number>`.
+
 ### Example Scripts
 
-An example automation script is available in the repository under [`examples/automations/`](examples/automations/). It demonstrates all three parameter source types: `hmkv_output` (encoded output directory), `prompt` (destination media directory), and `static` (group name to assign to files).
+An example automation script is available in the repository under [`examples/automations/`](examples/automations/). It demonstrates all three parameter source types: `hmkv_output` (encoded output directory), `prompt` (destination media directory), and `static` (group name).
 
 ## Multi-Disc Support
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Run history can be disabled entirely via the configuration wizard or by setting 
 
 Automations let you run local scripts or commands after HandyMKV finishes encoding. Each automation is a standalone configuration that defines a command to run and the parameters it needs. Parameters can be sourced from different places: prompted at runtime, hardcoded static defaults, or populated automatically from HandyMKV run data.
 
-Scripts receive their parameters as environment variables with the prefix `HMKV_PARAM_`. For example, a parameter named `destination_dir` becomes `HMKV_PARAM_DESTINATION_DIR`.
+Scripts receive their parameters as environment variables with the prefix `HMKV_PARAM_`. For example, a parameter named `destination_dir` becomes `HMKV_PARAM_DESTINATION_DIR`. Environment variables were chosen over command line arguments to maximize compatibility across programming languages and operating systems — argument parsing conventions vary widely between shells and runtimes (flag prefixes, quoting rules, whitespace handling), whereas environment variables are read the same way everywhere.
 
 ### Managing Automations
 

--- a/cmd/handymkv/main.go
+++ b/cmd/handymkv/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"slices"
 	"strconv"
@@ -28,12 +31,133 @@ func getVersion() string {
 
 func main() {
 	// Handle subcommands before flag.Parse()
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		hmkv.PrintLogo()
+
+		if len(os.Args) > 2 && os.Args[2] == "edit" {
+			configPath, err := hmkv.GetConfigFilePath()
+			if err != nil {
+				if err == hmkv.ErrConfigNotFound {
+					fmt.Printf("No config file found. Run 'handymkv config setup' to create one.\n\n")
+					return
+				}
+				fmt.Printf("Error locating config file: %v\n\n", err)
+				return
+			}
+			if err := openInEditor(configPath); err != nil {
+				if errors.Is(err, exec.ErrNotFound) {
+					fmt.Printf("No editor found. Set the EDITOR or VISUAL environment variable to specify your preferred editor.\nExample: export EDITOR=nano\n\n")
+				} else {
+					fmt.Printf("Could not open editor: %v\n\n", err)
+				}
+			}
+			return
+		}
+
+		if len(os.Args) > 2 && os.Args[2] == "setup" {
+			_, hb, err := checkForPrerequisites()
+			if err != nil {
+				outputFailedPrerequisiteCheck(err)
+				fmt.Print("Please run the configuration wizard again after addressing prerequisite dependency issues.\n\n")
+				fmt.Printf("Exiting.\n\n")
+				return
+			}
+			if err := hmkv.Setup(hb); err != nil {
+				fmt.Printf("An error occurred during the setup process.\nError: %v\n", err)
+			}
+			return
+		}
+
+		// Default: show current config
+		config, err := hmkv.ReadConfig()
+		if err != nil {
+			if err == hmkv.ErrConfigNotFound {
+				fmt.Printf("Config file not found. Please run 'handymkv config setup' to create one.\n\n")
+				return
+			}
+			fmt.Printf("An error occurred while reading the configuration file.\n\nError: %v\n", err)
+			return
+		}
+		fmt.Printf("Configuration file found.\n\n%s\n", config)
+		return
+	}
+
+	if len(os.Args) > 1 && os.Args[1] == "discs" {
+		hmkv.PrintLogo()
+
+		mkv, _, err := checkForPrerequisites()
+		if err != nil {
+			outputFailedPrerequisiteCheck(err)
+			fmt.Print("Exiting.\n\n")
+			return
+		}
+
+		fmt.Printf("Detecting available discs...\n\n")
+
+		discs, err := mkv.ListDiscs()
+		if err != nil {
+			fmt.Printf("An error occurred while listing the discs.\n\nError: %v\n", err)
+			return
+		}
+
+		if len(discs) < 1 {
+			fmt.Printf("No discs found.\n\n")
+			return
+		}
+
+		fmt.Printf("Available discs:\n\n")
+		for _, disc := range discs {
+			fmt.Printf("Disc - %d - %s\n", disc.Index, disc.Name)
+		}
+		fmt.Printf("\n")
+		return
+	}
+
+	if len(os.Args) > 1 && os.Args[1] == "automations" {
+		hmkv.PrintLogo()
+
+		if len(os.Args) > 2 {
+			switch os.Args[2] {
+			case "create":
+				if err := hmkv.CreateAutomation(); err != nil {
+					fmt.Printf("An error occurred creating automation: %v\n\n", err)
+				}
+				return
+			case "show":
+				if len(os.Args) < 4 {
+					fmt.Println("Usage: handymkv automations show <name>")
+					fmt.Println()
+					return
+				}
+				if err := hmkv.PrintAutomation(os.Args[3]); err != nil {
+					fmt.Printf("An error occurred: %v\n\n", err)
+				}
+				return
+			case "delete":
+				if len(os.Args) < 4 {
+					fmt.Println("Usage: handymkv automations delete <name>")
+					fmt.Println()
+					return
+				}
+				if err := hmkv.DeleteAutomation(os.Args[3]); err != nil {
+					fmt.Printf("An error occurred: %v\n\n", err)
+				}
+				return
+			}
+		}
+
+		if err := hmkv.PrintAutomations(); err != nil {
+			fmt.Printf("An error occurred listing automations: %v\n\n", err)
+		}
+		return
+	}
+
 	if len(os.Args) > 1 && os.Args[1] == "history" {
 		hmkv.PrintLogo()
 
 		cfg, cfgErr := hmkv.ReadConfig()
 		if cfgErr == hmkv.ErrConfigNotFound {
-			fmt.Println("No configuration found. Please run the configuration wizard with 'handymkv -c'.")
+			fmt.Println("No configuration found. Please run the configuration wizard with 'handymkv config setup'.")
 			fmt.Println()
 			return
 		}
@@ -66,24 +190,28 @@ func main() {
 
 	// Parse command line args
 	var discIds string
+	var automationNames string
 	var version bool
-	var readConfig bool
-	var configure bool
-	var listDiscs bool
 
 	flag.BoolVar(&version, "v", false, "Version. Prints the version of the application.")
-	flag.BoolVar(&configure, "c", false, "Configure. Runs the configuration wizard.")
-	flag.BoolVar(&readConfig, "r", false, "Read. Reads and outputs the first encountered configuration file. The current working directory is searched first, then the user-level configuration.")
-	flag.BoolVar(&listDiscs, "l", false, "List. Lists the available discs. The disc index is required to rip a disc. Drives without a valid disc inserted will not be listed.")
 	flag.StringVar(&discIds, "d", "0", "Discs. A comma delimited list of disc indexes to rip. Example: -d 0,1,2")
+	flag.StringVar(&automationNames, "a", "", "Automations. A comma delimited list of automation names to run after encoding. Example: -a move-to-plex,notify-discord")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 		flag.PrintDefaults()
 		fmt.Fprintf(flag.CommandLine.Output(), "\nSubcommands:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  config\n    \tShow the current configuration.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  config setup\n    \tRun the configuration wizard.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  config edit\n    \tOpen the config file in the default editor.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  discs\n    \tList available discs.\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  history\n    \tShow a summary list of past runs.\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  history <number>\n    \tShow details for a specific past run.\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  history clear\n    \tDelete all manifest files from the run history directory.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  automations\n    \tList all saved automations.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  automations create\n    \tCreate a new automation.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  automations show <name>\n    \tShow details of an automation.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  automations delete <name>\n    \tDelete an automation.\n")
 	}
 
 	flag.Parse()
@@ -95,68 +223,10 @@ func main() {
 		return
 	}
 
-	if configure {
-		_, hb, err := checkForPrerequisites()
-		if err != nil {
-			outputFailedPrerequisiteCheck(err)
-			fmt.Print("Please run the configuration wizard again after addressing prerequisite dependency issues.\n\n")
-			fmt.Printf("Exiting.\n\n")
-			return
-		}
-
-		err = hmkv.Setup(hb)
-		if err != nil {
-			fmt.Printf("An error occurred during the setup process.\nError: %v\n", err)
-		}
-
-		return
-	}
-
-	if readConfig {
-		config, err := hmkv.ReadConfig()
-		if err != nil {
-			if err == hmkv.ErrConfigNotFound {
-				fmt.Printf("Config file not found. Please run the configuration wizard with 'handy -c'.\n\n")
-				return
-			}
-
-			fmt.Printf("An error occurred while reading the configuration file.\n\nError: %v\n", err)
-			return
-		}
-
-		fmt.Printf("Configuration file found.\n\n%+v\n", config)
-
-		return
-	}
-
 	mkv, hb, err := checkForPrerequisites()
 	if err != nil {
 		outputFailedPrerequisiteCheck(err)
 		fmt.Print("Exiting.\n\n")
-		return
-	}
-
-	if listDiscs {
-		fmt.Printf("Detecting available discs...\n\n")
-
-		discs, err := mkv.ListDiscs()
-		if err != nil {
-			fmt.Printf("An error occurred while listing the discs.\n\nError: %v\n", err)
-			return
-		}
-
-		if len(discs) < 1 {
-			fmt.Printf("No discs found.\n\n")
-			return
-		}
-
-		fmt.Printf("Available discs:\n\n")
-
-		for _, disc := range discs {
-			fmt.Printf("Disc - %d - %s\n", disc.Index, disc.Name)
-		}
-
-		fmt.Printf("\n")
 		return
 	}
 
@@ -187,7 +257,17 @@ func main() {
 
 	slices.Sort(discIdInts)
 
-	err = hmkv.Exec(mkv, hb, discIdInts, getVersion())
+	var autoNames []string
+	if automationNames != "" {
+		for _, name := range strings.Split(automationNames, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				autoNames = append(autoNames, name)
+			}
+		}
+	}
+
+	err = hmkv.Exec(mkv, hb, discIdInts, getVersion(), autoNames)
 	if err != nil {
 		if err == hmkv.ErrConfigNotFound {
 			fmt.Printf("Config file not found. Please run the configuration wizard with 'handymkv -c'.\n\n")
@@ -256,3 +336,29 @@ var (
 	ErrHandBrakeCLIExecNotFound = fmt.Errorf("HandBrakeCLI executable not found")
 	ErrMakeMKVExecNotFound      = fmt.Errorf("MakeMKV executable not found")
 )
+
+func openInEditor(path string) error {
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+
+	var cmd *exec.Cmd
+	if editor != "" {
+		cmd = exec.Command(editor, path)
+	} else {
+		switch runtime.GOOS {
+		case "windows":
+			cmd = exec.Command("cmd", "/c", "start", "", path)
+		case "darwin":
+			cmd = exec.Command("open", "-t", path)
+		default:
+			cmd = exec.Command("xdg-open", path)
+		}
+	}
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/handymkv/main.go
+++ b/cmd/handymkv/main.go
@@ -259,10 +259,14 @@ func main() {
 
 	var autoNames []string
 	if automationNames != "" {
+		seen := make(map[string]struct{})
 		for _, name := range strings.Split(automationNames, ",") {
 			name = strings.TrimSpace(name)
 			if name != "" {
-				autoNames = append(autoNames, name)
+				if _, ok := seen[name]; !ok {
+					autoNames = append(autoNames, name)
+					seen[name] = struct{}{}
+				}
 			}
 		}
 	}

--- a/examples/automations/move-media.md
+++ b/examples/automations/move-media.md
@@ -8,9 +8,10 @@ The script changes the group ownership of encoded files and moves them to a medi
 
 For each file in the encoded output directory:
 
-1. Changes the file's group to the specified group name via `chgrp`
-2. Sets file permissions to `0774` (owner and group can read/write/execute, others can read)
-3. Moves the file to the destination media directory
+1. Strips the trailing `_t##` identifier from the filename before the extension (e.g. `My_Movie_t00.mkv` → `My_Movie.mkv`). This artifact is commonly added by MakeMKV during disc ripping.
+2. Changes the file's group to the specified group name via `chgrp`
+3. Sets file permissions to `0774` (owner and group can read/write/execute, others can read)
+4. Moves the file to the destination media directory with the cleaned filename
 
 ## Parameters
 
@@ -34,9 +35,9 @@ For each file in the encoded output directory:
    - **Command**: `/path/to/examples/automations/move-media.sh`
    - **Param 1**: name `encoded_dir`, source `hmkv_output`, key `hb_output_dir`
    - **Param 2**: name `media_dir`, source `prompt`
-   - **Param 3**: name `group_name`, source `prompt`, default `media`
+   - **Param 3**: name `group_name`, source `static`, value `media` (or your group name)
 
-3. Run HandyMKV and select the automation when prompted, or use the `-a` flag:
+3. Run HandyMKV with the `-a` flag:
 
    ```shell
    handymkv -a move-media

--- a/examples/automations/move-media.md
+++ b/examples/automations/move-media.md
@@ -1,0 +1,48 @@
+# move-media (Example Automation)
+
+This is an example automation script that demonstrates how to use HandyMKV's automations feature. It is meant to be adapted to your specific setup.
+
+The script changes the group ownership of encoded files and moves them to a media directory. It is useful when HandyMKV runs under a different user than the media server (e.g., Plex, Jellyfin) and the files need to be accessible to a shared group.
+
+## What it does
+
+For each file in the encoded output directory:
+
+1. Changes the file's group to the specified group name via `chgrp`
+2. Sets file permissions to `0774` (owner and group can read/write/execute, others can read)
+3. Moves the file to the destination media directory
+
+## Parameters
+
+| Name | Source | Description |
+|------|--------|-------------|
+| `encoded_dir` | `hmkv_output` (key: `hb_output_dir`) | The directory containing encoded files. Populated automatically by HandyMKV after encoding. |
+| `media_dir` | `prompt` | The destination directory to move files into. You will be asked for this before the run starts. |
+| `group_name` | `static` | The group to assign to each file. |
+
+## Setup
+
+1. Create the automation:
+
+   ```shell
+   handymkv automations create
+   ```
+
+2. Follow the prompts:
+
+   - **Name**: `move-media`
+   - **Command**: `/path/to/examples/automations/move-media.sh`
+   - **Param 1**: name `encoded_dir`, source `hmkv_output`, key `hb_output_dir`
+   - **Param 2**: name `media_dir`, source `prompt`
+   - **Param 3**: name `group_name`, source `prompt`, default `media`
+
+3. Run HandyMKV and select the automation when prompted, or use the `-a` flag:
+
+   ```shell
+   handymkv -a move-media
+   ```
+
+## Requirements
+
+- The user running HandyMKV must have permission to change file group ownership (either as root or as a member of the target group).
+- The target group must exist on the system. Create it with `sudo groupadd media` if needed.

--- a/examples/automations/move-media.sh
+++ b/examples/automations/move-media.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# move-media.sh
+#
+# Changes the group of encoded files and moves them
+# to a destination media directory.
+#
+# HandyMKV automation parameters (environment variables):
+#   HMKV_PARAM_ENCODED_DIR   - Source directory containing encoded files (hmkv_output: hb_output_dir)
+#   HMKV_PARAM_MEDIA_DIR     - Destination media directory (source: prompt)
+#   HMKV_PARAM_GROUP_NAME    - Group to assign to files (source: static)
+#
+
+set -euo pipefail
+
+if [ -z "${HMKV_PARAM_ENCODED_DIR:-}" ]; then
+    echo "Error: HMKV_PARAM_ENCODED_DIR is not set."
+    exit 1
+fi
+
+if [ -z "${HMKV_PARAM_MEDIA_DIR:-}" ]; then
+    echo "Error: HMKV_PARAM_MEDIA_DIR is not set."
+    exit 1
+fi
+
+if [ -z "${HMKV_PARAM_GROUP_NAME:-}" ]; then
+    echo "Error: HMKV_PARAM_GROUP_NAME is not set."
+    exit 1
+fi
+
+if [ ! -d "$HMKV_PARAM_ENCODED_DIR" ]; then
+    echo "Error: Encoded directory does not exist: $HMKV_PARAM_ENCODED_DIR"
+    exit 1
+fi
+
+mkdir -p "$HMKV_PARAM_MEDIA_DIR"
+
+find "$HMKV_PARAM_ENCODED_DIR" -type f | while read -r file; do
+    chgrp "$HMKV_PARAM_GROUP_NAME" "$file"
+    chmod 0774 "$file"
+    mv "$file" "$HMKV_PARAM_MEDIA_DIR/"
+    echo "Moved: $(basename "$file")"
+done
+
+echo "Done. Files moved to $HMKV_PARAM_MEDIA_DIR"

--- a/examples/automations/move-media.sh
+++ b/examples/automations/move-media.sh
@@ -36,10 +36,15 @@ fi
 mkdir -p "$HMKV_PARAM_MEDIA_DIR"
 
 find "$HMKV_PARAM_ENCODED_DIR" -type f | while read -r file; do
+    filename=$(basename "$file")
+
+    # Strip trailing _t## identifier before the extension (e.g. My_Movie_t00.mkv -> My_Movie.mkv)
+    cleaned=$(echo "$filename" | sed 's/_t[0-9][0-9]\(\.[^.]*\)$/\1/')
+
     chgrp "$HMKV_PARAM_GROUP_NAME" "$file"
     chmod 0774 "$file"
-    mv "$file" "$HMKV_PARAM_MEDIA_DIR/"
-    echo "Moved: $(basename "$file")"
+    mv "$file" "$HMKV_PARAM_MEDIA_DIR/$cleaned"
+    echo "Moved: $filename -> $cleaned"
 done
 
 echo "Done. Files moved to $HMKV_PARAM_MEDIA_DIR"

--- a/internal/hmkv/automation.go
+++ b/internal/hmkv/automation.go
@@ -1,0 +1,457 @@
+package hmkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type AutomationParamSource string
+
+const (
+	ParamSourcePrompt     AutomationParamSource = "prompt"
+	ParamSourceStatic     AutomationParamSource = "static"
+	ParamSourceHMKVOutput AutomationParamSource = "hmkv_output"
+)
+
+var validParamSources = []string{
+	string(ParamSourcePrompt),
+	string(ParamSourceStatic),
+	string(ParamSourceHMKVOutput),
+}
+
+var validHMKVKeys = []string{
+	"hb_output_dir",
+	"mkv_output_dir",
+	"run_duration",
+	"raw_files_deleted",
+	"title_count",
+	"total_raw_size",
+	"total_encoded_size",
+}
+
+type AutomationParam struct {
+	Name         string                `json:"name"`
+	Description  string                `json:"description"`
+	Source       AutomationParamSource `json:"source"`
+	DefaultValue string                `json:"default_value,omitempty"`
+	HMKVKey      string                `json:"hmkv_key,omitempty"`
+}
+
+type Automation struct {
+	Name    string            `json:"name"`
+	Command string            `json:"command"`
+	Params  []AutomationParam `json:"params,omitempty"`
+}
+
+// getAutomationsDir returns the OS-appropriate automations directory path.
+func getAutomationsDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA environment variable is not set")
+		}
+		return filepath.Join(appData, "handymkv", "automations"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".config", "handymkv", "automations"), nil
+}
+
+// ListAutomations reads all automation JSON files from the automations directory.
+func ListAutomations() ([]Automation, error) {
+	dir, err := getAutomationsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	pattern := filepath.Join(dir, "*.json")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("error scanning automations directory: %w", err)
+	}
+
+	var automations []Automation
+	for _, f := range files {
+		a, err := readAutomationFile(f)
+		if err != nil {
+			continue
+		}
+		automations = append(automations, *a)
+	}
+
+	return automations, nil
+}
+
+// LoadAutomation reads a single automation by name.
+func LoadAutomation(name string) (*Automation, error) {
+	dir, err := getAutomationsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	filePath := filepath.Join(dir, name+".json")
+	return readAutomationFile(filePath)
+}
+
+func readAutomationFile(path string) (*Automation, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var a Automation
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// SaveAutomation writes an automation JSON file to the automations directory.
+func SaveAutomation(a *Automation) error {
+	dir, err := getAutomationsDir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0740); err != nil {
+		return fmt.Errorf("could not create automations directory: %w", err)
+	}
+
+	filePath := filepath.Join(dir, a.Name+".json")
+
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not marshal automation: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0640); err != nil {
+		return fmt.Errorf("could not write automation file: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteAutomation deletes an automation file after confirmation.
+func DeleteAutomation(name string) error {
+	dir, err := getAutomationsDir()
+	if err != nil {
+		return err
+	}
+
+	filePath := filepath.Join(dir, name+".json")
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		fmt.Printf("Automation '%s' not found.\n\n", name)
+		return nil
+	}
+
+	fmt.Printf("Delete automation '%s'? [y/N]: ", name)
+
+	if strings.ToLower(readLine()) != "y" {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	if err := os.Remove(filePath); err != nil {
+		return fmt.Errorf("could not delete automation: %w", err)
+	}
+
+	fmt.Printf("Automation '%s' deleted.\n\n", name)
+	return nil
+}
+
+// PrintAutomations lists all saved automations.
+func PrintAutomations() error {
+	automations, err := ListAutomations()
+	if err != nil {
+		return err
+	}
+
+	if len(automations) == 0 {
+		fmt.Println("No automations found.")
+		fmt.Println("Run 'handymkv automations create' to create one.")
+		fmt.Println()
+		return nil
+	}
+
+	fmt.Printf("Saved Automations:\n\n")
+
+	for i, a := range automations {
+		paramCount := len(a.Params)
+		paramLabel := "params"
+		if paramCount == 1 {
+			paramLabel = "param"
+		}
+		fmt.Printf("  %d. %s - %s (%d %s)\n", i+1, a.Name, a.Command, paramCount, paramLabel)
+	}
+
+	fmt.Printf("\nRun 'handymkv automations show <name>' to view details.\n\n")
+	return nil
+}
+
+// PrintAutomation shows the details of a single automation.
+func PrintAutomation(name string) error {
+	a, err := LoadAutomation(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("Automation '%s' not found.\n\n", name)
+			return nil
+		}
+		return err
+	}
+
+	fmt.Printf("Automation: %s\n", a.Name)
+	fmt.Printf("Command:    %s\n", a.Command)
+
+	if len(a.Params) == 0 {
+		fmt.Printf("Parameters: none\n")
+	} else {
+		fmt.Printf("Parameters:\n\n")
+		for _, p := range a.Params {
+			envVarName := "HMKV_PARAM_" + strings.ToUpper(p.Name)
+			fmt.Printf("  %s -> %s\n", p.Name, envVarName)
+			fmt.Printf("    Description: %s\n", p.Description)
+			fmt.Printf("    Source:      %s\n", p.Source)
+
+			switch p.Source {
+			case ParamSourcePrompt:
+				if p.DefaultValue != "" {
+					fmt.Printf("    Default:     %s\n", p.DefaultValue)
+				}
+			case ParamSourceStatic:
+				fmt.Printf("    Value:       %s\n", p.DefaultValue)
+			case ParamSourceHMKVOutput:
+				fmt.Printf("    HMKV Key:    %s\n", p.HMKVKey)
+			}
+
+			fmt.Println()
+		}
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// CreateAutomation runs the interactive wizard to create a new automation.
+func CreateAutomation() error {
+	fmt.Println("Create a new automation")
+	fmt.Println()
+	fmt.Println("Note: Automation scripts receive parameters as environment variables.")
+	fmt.Println("Each parameter is available as HMKV_PARAM_<UPPERCASED_NAME>.")
+	fmt.Println()
+
+	name := promptForString(
+		"Automation name:",
+		"A short identifier for this automation.",
+		"",
+		nil,
+	)
+
+	if name == "" {
+		fmt.Println("Name is required.")
+		return nil
+	}
+
+	// Sanitize name for use as filename
+	name = strings.ReplaceAll(strings.TrimSpace(name), " ", "-")
+
+	command := promptForString(
+		"Command to execute:",
+		"The script or command that will be run after encoding completes.",
+		"",
+		nil,
+	)
+
+	if command == "" {
+		fmt.Println("Command is required.")
+		return nil
+	}
+
+	var params []AutomationParam
+
+	for {
+		addParam := promptForBool("Add a parameter?", "", false)
+
+		if !addParam {
+			break
+		}
+
+		clear()
+
+		param := AutomationParam{}
+
+		param.Name = promptForString("Parameter name:", "A short identifier (becomes HMKV_PARAM_<UPPERCASED_NAME>).", "", nil)
+		if param.Name == "" {
+			fmt.Println("Parameter name is required. Skipping.")
+			continue
+		}
+
+		param.Description = promptForString("Description:", "Explain what this parameter is for.", "", nil)
+
+		source := promptForSelection("Parameter source:", validParamSources)
+		param.Source = AutomationParamSource(source)
+
+		switch param.Source {
+		case ParamSourcePrompt:
+			param.DefaultValue = promptForString("Default value (optional):", "Shown to user when prompted. Leave blank for no default.", "", nil)
+		case ParamSourceStatic:
+			param.DefaultValue = promptForString("Static value:", "The hardcoded value for this parameter.", "", nil)
+			if param.DefaultValue == "" {
+				fmt.Println("Default value is required. Skipping parameter.")
+				continue
+			}
+		case ParamSourceHMKVOutput:
+			param.HMKVKey = promptForSelection("HandyMKV output key:", validHMKVKeys)
+		}
+
+		params = append(params, param)
+		clear()
+	}
+
+	a := &Automation{
+		Name:    name,
+		Command: command,
+		Params:  params,
+	}
+
+	if err := SaveAutomation(a); err != nil {
+		return fmt.Errorf("could not save automation: %w", err)
+	}
+
+	dir, _ := getAutomationsDir()
+	fmt.Printf("Automation '%s' saved to %s\n\n", a.Name, filepath.Join(dir, a.Name+".json"))
+	return nil
+}
+
+// resolvePreRunParams collects prompt/env/default param values before the run starts.
+// Deduplicates by param name across automations.
+func resolvePreRunParams(automations []Automation) (map[string]string, error) {
+	resolved := make(map[string]string)
+
+	for _, a := range automations {
+		for _, p := range a.Params {
+			if _, exists := resolved[p.Name]; exists {
+				continue
+			}
+
+			switch p.Source {
+			case ParamSourcePrompt:
+				val := promptForString(
+					fmt.Sprintf("[%s] %s:", a.Name, p.Description),
+					"",
+					p.DefaultValue,
+					nil,
+				)
+				resolved[p.Name] = val
+
+			case ParamSourceStatic:
+				resolved[p.Name] = p.DefaultValue
+
+			case ParamSourceHMKVOutput:
+				// Resolved after the run completes; skip here
+				continue
+			}
+		}
+	}
+
+	return resolved, nil
+}
+
+// buildRunOutputData maps hmkv_key values to run output data.
+func buildRunOutputData(
+	hbDir string,
+	mkvDir string,
+	duration time.Duration,
+	titleCount int,
+	rawDeleted bool,
+	totalRaw int64,
+	totalEncoded int64,
+) map[string]string {
+	rawDeletedStr := "false"
+	if rawDeleted {
+		rawDeletedStr = "true"
+	}
+
+	return map[string]string{
+		"hb_output_dir":      hbDir,
+		"mkv_output_dir":     mkvDir,
+		"run_duration":       formatTimeElapsedString(duration),
+		"raw_files_deleted":  rawDeletedStr,
+		"title_count":        fmt.Sprintf("%d", titleCount),
+		"total_raw_size":     fmt.Sprintf("%d", totalRaw),
+		"total_encoded_size": fmt.Sprintf("%d", totalEncoded),
+	}
+}
+
+// RunAutomations executes selected automations with resolved parameters.
+// Returns manifest entries recording each automation's name, command, and resolved param values.
+func RunAutomations(automations []Automation, preRunParams map[string]string, outputData map[string]string) []manifestAutomation {
+	if len(automations) == 0 {
+		return nil
+	}
+
+	fmt.Println("\nRunning automations...")
+
+	var entries []manifestAutomation
+
+	for _, a := range automations {
+		// Build environment and collect resolved params for manifest
+		env := os.Environ()
+		var manifestParams []manifestAutomationParam
+
+		for _, p := range a.Params {
+			envKey := "HMKV_PARAM_" + strings.ToUpper(p.Name)
+			var val string
+
+			if p.Source == ParamSourceHMKVOutput {
+				val = outputData[p.HMKVKey]
+			} else {
+				val = preRunParams[p.Name]
+			}
+
+			env = append(env, fmt.Sprintf("%s=%s", envKey, val))
+			manifestParams = append(manifestParams, manifestAutomationParam{
+				Name:  p.Name,
+				Value: val,
+			})
+		}
+
+		entries = append(entries, manifestAutomation{
+			Name:    a.Name,
+			Command: a.Command,
+			Params:  manifestParams,
+		})
+
+		// Execute via shell
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = exec.Command("cmd", "/c", a.Command)
+		} else {
+			cmd = exec.Command("sh", "-c", a.Command)
+		}
+
+		cmd.Env = env
+
+		err := cmd.Run()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				fmt.Printf("  %s: FAILED (exit code %d)\n", a.Name, exitErr.ExitCode())
+			} else {
+				fmt.Printf("  %s: FAILED (%v)\n", a.Name, err)
+			}
+		} else {
+			fmt.Printf("  %s: OK\n", a.Name)
+		}
+	}
+
+	fmt.Println()
+	return entries
+}

--- a/internal/hmkv/automation.go
+++ b/internal/hmkv/automation.go
@@ -49,6 +49,14 @@ type Automation struct {
 	Params  []AutomationParam `json:"params,omitempty"`
 }
 
+// validateAutomationName rejects names that could escape the automations directory.
+func validateAutomationName(name string) error {
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return fmt.Errorf("automation name '%s' contains invalid characters (no path separators or '..' allowed)", name)
+	}
+	return nil
+}
+
 // getAutomationsDir returns the OS-appropriate automations directory path.
 func getAutomationsDir() (string, error) {
 	if runtime.GOOS == "windows" {
@@ -83,6 +91,7 @@ func ListAutomations() ([]Automation, error) {
 	for _, f := range files {
 		a, err := readAutomationFile(f)
 		if err != nil {
+			fmt.Printf("Warning: could not load automation file '%s': %v\n", filepath.Base(f), err)
 			continue
 		}
 		automations = append(automations, *a)
@@ -93,6 +102,10 @@ func ListAutomations() ([]Automation, error) {
 
 // LoadAutomation reads a single automation by name.
 func LoadAutomation(name string) (*Automation, error) {
+	if err := validateAutomationName(name); err != nil {
+		return nil, err
+	}
+
 	dir, err := getAutomationsDir()
 	if err != nil {
 		return nil, err
@@ -110,6 +123,9 @@ func readAutomationFile(path string) (*Automation, error) {
 	var a Automation
 	if err := json.Unmarshal(data, &a); err != nil {
 		return nil, err
+	}
+	if a.Command == "" {
+		return nil, fmt.Errorf("automation '%s' has an empty command field", a.Name)
 	}
 	return &a, nil
 }
@@ -141,6 +157,10 @@ func SaveAutomation(a *Automation) error {
 
 // DeleteAutomation deletes an automation file after confirmation.
 func DeleteAutomation(name string) error {
+	if err := validateAutomationName(name); err != nil {
+		return err
+	}
+
 	dir, err := getAutomationsDir()
 	if err != nil {
 		return err
@@ -262,6 +282,11 @@ func CreateAutomation() error {
 
 	// Sanitize name for use as filename
 	name = strings.ReplaceAll(strings.TrimSpace(name), " ", "-")
+
+	if err := validateAutomationName(name); err != nil {
+		fmt.Printf("Invalid name: %v\n", err)
+		return nil
+	}
 
 	command := promptForString(
 		"Command to execute:",
@@ -424,12 +449,6 @@ func RunAutomations(automations []Automation, preRunParams map[string]string, ou
 			})
 		}
 
-		entries = append(entries, manifestAutomation{
-			Name:    a.Name,
-			Command: a.Command,
-			Params:  manifestParams,
-		})
-
 		// Execute via shell
 		var cmd *exec.Cmd
 		if runtime.GOOS == "windows" {
@@ -440,16 +459,26 @@ func RunAutomations(automations []Automation, preRunParams map[string]string, ou
 
 		cmd.Env = env
 
+		exitCode := 0
 		err := cmd.Run()
 		if err != nil {
 			if exitErr, ok := err.(*exec.ExitError); ok {
-				fmt.Printf("  %s: FAILED (exit code %d)\n", a.Name, exitErr.ExitCode())
+				exitCode = exitErr.ExitCode()
+				fmt.Printf("  %s: FAILED (exit code %d)\n", a.Name, exitCode)
 			} else {
+				exitCode = -1
 				fmt.Printf("  %s: FAILED (%v)\n", a.Name, err)
 			}
 		} else {
 			fmt.Printf("  %s: OK\n", a.Name)
 		}
+
+		entries = append(entries, manifestAutomation{
+			Name:     a.Name,
+			Command:  a.Command,
+			Params:   manifestParams,
+			ExitCode: exitCode,
+		})
 	}
 
 	fmt.Println()

--- a/internal/hmkv/conf.go
+++ b/internal/hmkv/conf.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -26,12 +27,12 @@ var ErrConfigNotFound = errors.New("config file not found")
 type configFileLocation int
 
 type handyMKVConfig struct {
-	EncodeConfig        EncodingParams `json:"encoding_params"`
-	MKVOutputDirectory  string         `json:"mkv_output_directory"`
-	HBOutputDirectory   string         `json:"handbrake_output_directory"`
-	DeleteRawMKVFiles   bool           `json:"delete_raw_mkv_files"`
-	DisableManifests    bool           `json:"disable_manifests,omitempty"`
-	ManifestDirectory   string         `json:"manifest_directory,omitempty"`
+	EncodeConfig       EncodingParams `json:"encoding_params"`
+	MKVOutputDirectory string         `json:"mkv_output_directory"`
+	HBOutputDirectory  string         `json:"handbrake_output_directory"`
+	DeleteRawMKVFiles  bool           `json:"delete_raw_mkv_files"`
+	DisableManifests   bool           `json:"disable_manifests,omitempty"`
+	ManifestDirectory  string         `json:"manifest_directory,omitempty"`
 }
 
 func (config *handyMKVConfig) String() string {
@@ -96,6 +97,23 @@ func getUserConfigPath() (string, error) {
 		}
 		return filepath.Join(usr.HomeDir, ".config", "handymkv", configFileName), nil
 	}
+}
+
+// GetConfigFilePath returns the path of the active config file, using the same
+// discovery order as ReadConfig: local ./config.json first, then the user config directory.
+func GetConfigFilePath() (string, error) {
+	local := fmt.Sprintf("./%s", configFileName)
+	if _, err := os.Stat(local); err == nil {
+		return local, nil
+	}
+	userPath, err := getUserConfigPath()
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(userPath); err == nil {
+		return userPath, nil
+	}
+	return "", ErrConfigNotFound
 }
 
 // Reads the config file and returns a config struct.
@@ -223,9 +241,7 @@ func createConfigFile(location configFileLocation, config *handyMKVConfig, overw
 	// Check if the config file already exists
 	if _, err := os.Stat(configPath); err == nil && !overwrite {
 		fmt.Printf("\nA config file already exists at %s. Overwrite? [y/N]\n\n", configPath)
-		var choice string
-		fmt.Scanln(&choice)
-		if strings.ToLower(choice) != "y" {
+		if strings.ToLower(readLine()) != "y" {
 			fmt.Printf("\nSkipping creation of config file. The file %s already exists.\n", configPath)
 			return nil
 		}
@@ -262,7 +278,7 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 	var encoderSelection int
 
 	for {
-		fmt.Scanln(&encoderSelection)
+		encoderSelection, _ = strconv.Atoi(readLine())
 
 		if encoderSelection == 1 || encoderSelection == 2 || encoderSelection == 3 {
 			break
@@ -292,7 +308,7 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 		fmt.Printf("2 - Numeric Quality Value\n\n")
 
 		for {
-			fmt.Scanln(&qualitySelection)
+			qualitySelection, _ = strconv.Atoi(readLine())
 
 			if qualitySelection == 1 || qualitySelection == 2 {
 				break
@@ -324,7 +340,7 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 			"any")
 		clear()
 
-		config.EncodeConfig.IncludeAllRelevantAudio = promptForBool("Include all relevant audio tracks in encoded output files? [y/N]",
+		config.EncodeConfig.IncludeAllRelevantAudio = promptForBool("Include all relevant audio tracks in encoded output files?",
 			"Some discs contain multiple audio tracks in the same language. If this option is enabled, all audio tracks in the same language will be included in the encoded output files. If this option is disabled, only the first audio track in the specified language will be included.",
 			true)
 		clear()
@@ -334,7 +350,7 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 			"eng")
 		clear()
 
-		config.EncodeConfig.IncludeAllRelevantSubtitles = promptForBool("Include all relevant subtitle tracks in encoded output files? [y/N]",
+		config.EncodeConfig.IncludeAllRelevantSubtitles = promptForBool("Include all relevant subtitle tracks in encoded output files?",
 			"Some discs contain multiple subtitle tracks in the same language. If this option is enabled, all subtitle tracks in the same language will be included in the encoded output files.",
 			true)
 		clear()
@@ -424,14 +440,14 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 
 	clear()
 
-	config.DeleteRawMKVFiles = promptForBool("Automatically delete raw unencoded files after ripping/encoding operations? [y/N]",
+	config.DeleteRawMKVFiles = promptForBool("Automatically delete raw unencoded files after ripping/encoding operations?",
 		"If enabled, raw unencoded mkv files will be deleted after the ripping/encoding operation completes. If disabled, raw unencoded files will be retained. Leaving this option enabled is recommended as it will save space on the disk.",
 		true)
 
 	clear()
 
 	config.DisableManifests = promptForBool(
-		"Disable run history logging? [y/N]",
+		"Disable run history logging?",
 		"If disabled, handymkv will not write manifest files after each run. Run history will not be available.",
 		false,
 	)

--- a/internal/hmkv/fs.go
+++ b/internal/hmkv/fs.go
@@ -24,6 +24,12 @@ func getFileSize(filePath string) (int64, error) {
 }
 
 func deleteRawFiles(config *handyMKVConfig) {
+	// Check if the directory still exists (it may have been moved by an automation)
+	if _, err := os.Stat(config.MKVOutputDirectory); os.IsNotExist(err) {
+		fmt.Printf("\nRaw MKV output directory no longer exists (may have been moved by an automation). Skipping deletion.\n")
+		return
+	}
+
 	fmt.Printf("\nDeleting raw unencoded files...\n\n")
 
 	// Delete entire MKV output directory
@@ -31,6 +37,7 @@ func deleteRawFiles(config *handyMKVConfig) {
 
 	if err != nil {
 		fmt.Printf("An error occurred while deleting the MKV output directory: %v\n", err)
+		return
 	}
 
 	fmt.Printf("Raw unencoded files deleted.\n")

--- a/internal/hmkv/hmkv.go
+++ b/internal/hmkv/hmkv.go
@@ -15,7 +15,7 @@ import (
 // Executes the main functionality of the program.
 // Reads the configuration file, reads titles from the disc, prompts the user for which titles they want to rip,
 // and processes the selected titles.
-func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) error {
+func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string, automationNames []string) error {
 	config, err := ReadConfig()
 
 	if err != nil {
@@ -61,7 +61,7 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) erro
 
 		// Prompt the user for input
 		fmt.Print("\nEnter the IDs of the titles to process (0,1,2...) or enter 'all' to process all titles: \n\n")
-		fmt.Scanln(&titleSelections)
+		titleSelections = readLine()
 
 		// Remove invalid characters
 		titleSelections = strings.ReplaceAll(titleSelections, " ", "")
@@ -119,9 +119,9 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) erro
 		discNames[strings.ToLower(title.DiscTitle)]++
 	}
 
-	for _, title := range processTitles {
-		if discNames[strings.ToLower(title.DiscTitle)] > 1 {
-			title.SetPrependDiscToSubdirectory(true)
+	for i := range processTitles {
+		if discNames[strings.ToLower(processTitles[i].DiscTitle)] > 1 {
+			processTitles[i].SetPrependDiscToSubdirectory(true)
 		}
 	}
 
@@ -162,6 +162,28 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) erro
 	}
 
 	fmt.Println()
+
+	// Automation selection and pre-run param collection
+	var selectedAutomations []Automation
+	var preRunParams map[string]string
+
+	for _, name := range automationNames {
+		a, err := LoadAutomation(name)
+		if err != nil {
+			fmt.Printf("Warning: could not load automation '%s': %v\n", name, err)
+			continue
+		}
+		selectedAutomations = append(selectedAutomations, *a)
+	}
+
+	if len(selectedAutomations) > 0 {
+		var paramErr error
+		preRunParams, paramErr = resolvePreRunParams(selectedAutomations)
+		if paramErr != nil {
+			fmt.Printf("Warning: %v\nAutomations will be skipped.\n\n", paramErr)
+			selectedAutomations = nil
+		}
+	}
 
 	ctx, cancelProcessing := context.WithCancel(context.Background())
 	var encChannel = make(chan EncodingParams, len(processTitles))
@@ -281,28 +303,6 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) erro
 
 	processDuration := time.Since(processStartTime).Round(time.Second)
 
-	// Write run manifest
-	if !config.DisableManifests {
-		manifestDir := config.ManifestDirectory
-		if manifestDir == "" {
-			var mdErr error
-			manifestDir, mdErr = getManifestDir()
-			if mdErr != nil {
-				fmt.Printf("\nWarning: could not determine manifest directory: %v\n", mdErr)
-				manifestDir = ""
-			}
-		}
-		if manifestDir != "" {
-			m := buildManifest(processTitles, manifestEntries, processStartTime, processDuration, config.DeleteRawMKVFiles, appVersion)
-			manifestPath, wErr := writeManifest(manifestDir, processStartTime, m)
-			if wErr != nil {
-				fmt.Printf("\nWarning: could not write manifest: %v\n", wErr)
-			} else {
-				fmt.Printf("\nManifest written to: %s\n", manifestPath)
-			}
-		}
-	}
-
 	fmt.Printf("\nOperation Complete. Time Elapsed - %s\n", formatTimeElapsedString(processDuration))
 
 	totalSizeRaw, totalSizeEncoded, err := calculateTotalFileSizes(processTitles, config)
@@ -317,6 +317,44 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string) erro
 	savedSpace := totalSizeRaw - totalSizeEncoded
 	if savedSpace > 0 {
 		fmt.Printf("Total disk space saved via encoding - %s\n", formatSavedSpace(totalSizeRaw-totalSizeEncoded))
+	}
+
+	// Run automations before raw file deletion so scripts can access raw MKV files
+	var automationEntries []manifestAutomation
+	if len(selectedAutomations) > 0 {
+		outputData := buildRunOutputData(
+			config.HBOutputDirectory,
+			config.MKVOutputDirectory,
+			processDuration,
+			len(processTitles),
+			config.DeleteRawMKVFiles,
+			totalSizeRaw,
+			totalSizeEncoded,
+		)
+		automationEntries = RunAutomations(selectedAutomations, preRunParams, outputData)
+	}
+
+	// Write run manifest (after automations so it can record automation data)
+	if !config.DisableManifests {
+		manifestDir := config.ManifestDirectory
+		if manifestDir == "" {
+			var mdErr error
+			manifestDir, mdErr = getManifestDir()
+			if mdErr != nil {
+				fmt.Printf("Warning: could not determine manifest directory: %v\n", mdErr)
+				manifestDir = ""
+			}
+		}
+		if manifestDir != "" {
+			m := buildManifest(processTitles, manifestEntries, processStartTime, processDuration, config.DeleteRawMKVFiles, appVersion, automationEntries)
+			manifestPath, wErr := writeManifest(manifestDir, processStartTime, m)
+			if wErr != nil {
+				fmt.Printf("Warning: could not write manifest: %v\n", wErr)
+			} else {
+				fmt.Printf("Manifest written to: %s\n", manifestPath)
+			}
+			_ = manifestPath
+		}
 	}
 
 	if config.DeleteRawMKVFiles {
@@ -414,9 +452,7 @@ func Setup(hb *HandBrakeCLI) error {
 	fmt.Println("2 - Current working directory.")
 	fmt.Println()
 
-	var configLocationSelectionString string
-
-	fmt.Scanln(&configLocationSelectionString)
+	configLocationSelectionString := readLine()
 
 	fmt.Println()
 
@@ -445,10 +481,7 @@ func Setup(hb *HandBrakeCLI) error {
 		fmt.Printf("\n%s\n", config.String())
 		fmt.Printf("Accept these settings? [y/N]\n\n")
 
-		var choice string
-		fmt.Scanln(&choice)
-
-		if strings.ToLower(choice) == "y" {
+		if strings.ToLower(readLine()) == "y" {
 			break
 		}
 	}

--- a/internal/hmkv/hmkv.go
+++ b/internal/hmkv/hmkv.go
@@ -353,7 +353,6 @@ func Exec(mkv *MakeMKV, hb *HandBrakeCLI, discIds []int, appVersion string, auto
 			} else {
 				fmt.Printf("Manifest written to: %s\n", manifestPath)
 			}
-			_ = manifestPath
 		}
 	}
 

--- a/internal/hmkv/manifest.go
+++ b/internal/hmkv/manifest.go
@@ -34,9 +34,10 @@ type manifestAutomationParam struct {
 }
 
 type manifestAutomation struct {
-	Name    string                    `json:"name"`
-	Command string                    `json:"command"`
-	Params  []manifestAutomationParam `json:"params,omitempty"`
+	Name     string                    `json:"name"`
+	Command  string                    `json:"command"`
+	Params   []manifestAutomationParam `json:"params,omitempty"`
+	ExitCode int                       `json:"exit_code"`
 }
 
 type manifest struct {
@@ -309,7 +310,11 @@ func PrintHistory(index int) error {
 	if len(m.Automations) > 0 {
 		fmt.Printf("\nAutomations:\n")
 		for _, a := range m.Automations {
-			fmt.Printf("  %s (%s)\n", a.Name, a.Command)
+			outcome := "OK"
+			if a.ExitCode != 0 {
+				outcome = fmt.Sprintf("FAILED (exit code %d)", a.ExitCode)
+			}
+			fmt.Printf("  %s (%s) — %s\n", a.Name, a.Command, outcome)
 			for _, p := range a.Params {
 				fmt.Printf("    %s = %s\n", p.Name, p.Value)
 			}

--- a/internal/hmkv/manifest.go
+++ b/internal/hmkv/manifest.go
@@ -28,12 +28,24 @@ type manifestDisc struct {
 	Titles   []manifestTitle `json:"titles"`
 }
 
+type manifestAutomationParam struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type manifestAutomation struct {
+	Name    string                    `json:"name"`
+	Command string                    `json:"command"`
+	Params  []manifestAutomationParam `json:"params,omitempty"`
+}
+
 type manifest struct {
-	AppVersion      string         `json:"app_version"`
-	Date            time.Time      `json:"date"`
-	Duration        string         `json:"duration"`
-	RawFilesDeleted bool           `json:"raw_files_deleted"`
-	Discs           []manifestDisc `json:"discs"`
+	AppVersion      string                `json:"app_version"`
+	Date            time.Time             `json:"date"`
+	Duration        string                `json:"duration"`
+	RawFilesDeleted bool                  `json:"raw_files_deleted"`
+	Discs           []manifestDisc        `json:"discs"`
+	Automations     []manifestAutomation  `json:"automations,omitempty"`
 }
 
 // getManifestDir returns ~/.config/handymkv/manifests/ on Unix or %APPDATA%\handymkv\manifests\ on Windows.
@@ -71,7 +83,7 @@ func normalizeHHMMSS(s string) string {
 }
 
 // buildManifest groups entries by disc (preserving order from processTitles) and builds a manifest struct.
-func buildManifest(processTitles []TitleInfo, entries []EncodingParams, startTime time.Time, duration time.Duration, rawDeleted bool, appVersion string) *manifest {
+func buildManifest(processTitles []TitleInfo, entries []EncodingParams, startTime time.Time, duration time.Duration, rawDeleted bool, appVersion string, automations []manifestAutomation) *manifest {
 	// Build disc name and duration lookups from processTitles
 	discNames := make(map[int]string)
 	type discTitle struct{ discId, titleIndex int }
@@ -121,6 +133,7 @@ func buildManifest(processTitles []TitleInfo, entries []EncodingParams, startTim
 		Duration:        duration.String(),
 		RawFilesDeleted: rawDeleted,
 		Discs:           discs,
+		Automations:     automations,
 	}
 }
 
@@ -177,10 +190,9 @@ func ClearHistory() error {
 	fmt.Printf("This will permanently delete %d manifest file(s) from:\n  %s\n\n", len(files), manifestDir)
 	fmt.Printf("Are you sure? [y/N]: ")
 
-	var choice string
-	fmt.Scanln(&choice)
+	choice := readLine()
 
-	if strings.ToLower(strings.TrimSpace(choice)) != "y" {
+	if strings.ToLower(choice) != "y" {
 		fmt.Println("Aborted.")
 		return nil
 	}
@@ -291,6 +303,16 @@ func PrintHistory(index int) error {
 			fmt.Printf("    Rip Duration:   %s\n", t.RippingDuration)
 			fmt.Printf("    Raw File:       %s (%s)\n", t.RippedFile, formatSavedSpace(t.RippedFileSizeBytes))
 			fmt.Printf("    Encoded File:   %s (%s)\n", t.EncodedFile, formatSavedSpace(t.EncodedFileSizeBytes))
+		}
+	}
+
+	if len(m.Automations) > 0 {
+		fmt.Printf("\nAutomations:\n")
+		for _, a := range m.Automations {
+			fmt.Printf("  %s (%s)\n", a.Name, a.Command)
+			for _, p := range a.Params {
+				fmt.Printf("    %s = %s\n", p.Name, p.Value)
+			}
 		}
 	}
 

--- a/internal/hmkv/term.go
+++ b/internal/hmkv/term.go
@@ -1,11 +1,20 @@
 package hmkv
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+var stdinReader = bufio.NewReader(os.Stdin)
+
+func readLine() string {
+	line, _ := stdinReader.ReadString('\n')
+	return strings.TrimSpace(line)
+}
 
 // ANSI color codes
 const (
@@ -59,7 +68,6 @@ func padString(s string, width int) (string, bool) {
 }
 
 func promptForSelection(prompt string, options []string) string {
-	var input string
 	fmt.Printf("%s\n\n", prompt)
 
 	// list options with a number so the user can select one
@@ -73,7 +81,7 @@ func promptForSelection(prompt string, options []string) string {
 
 	for {
 		fmt.Println()
-		fmt.Scanln(&input)
+		input := readLine()
 
 		// Make sure the input is a number
 		selection, err := strconv.Atoi(input)
@@ -95,12 +103,12 @@ func promptForSelection(prompt string, options []string) string {
 		break
 	}
 
+	fmt.Println()
 	return result
 }
 
 // Prompts the user for a string value. If the user provides an empty string, the default value is returned.
 func promptForString(prompt, explain, defaultValue string, validValues []string) string {
-	var input string
 	fmt.Printf("%s\n\n", prompt)
 
 	if explain != "" {
@@ -122,10 +130,8 @@ func promptForString(prompt, explain, defaultValue string, validValues []string)
 		fmt.Printf("\nDefault: %s\n\n", defaultValue)
 	}
 
-	fmt.Scanln(&input)
+	input := readLine()
 	fmt.Println()
-
-	input = strings.TrimSpace(input)
 
 	if input == "" {
 		return defaultValue
@@ -136,31 +142,24 @@ func promptForString(prompt, explain, defaultValue string, validValues []string)
 
 // Prompts the user for an integer value. If the user provides an empty string, the default value is returned.
 func promptForInt(prompt string) int {
-	var input string
 	fmt.Printf("%s\n\n", prompt)
 
-	var value int
-	var err error
-
 	for {
-		fmt.Scanln(&input)
+		input := readLine()
 
-		value, err = strconv.Atoi(input)
+		value, err := strconv.Atoi(input)
 
 		if err != nil {
 			fmt.Printf("\nInvalid value. Please enter a number.\n")
 			continue
 		}
 
-		break
+		return value
 	}
-
-	return value
 }
 
 // Prompts the user for a string slice value. If the user provides an empty string, the default value is returned.
 func promptForStringSlice(prompt, explain, defaultValue string) []string {
-	var input string
 	fmt.Printf("%s\n\n", prompt)
 
 	if explain != "" {
@@ -171,7 +170,7 @@ func promptForStringSlice(prompt, explain, defaultValue string) []string {
 		fmt.Printf("Default: %s\n\n", defaultValue)
 	}
 
-	fmt.Scanln(&input)
+	input := readLine()
 	fmt.Println()
 
 	if input == "" {
@@ -183,29 +182,27 @@ func promptForStringSlice(prompt, explain, defaultValue string) []string {
 
 // Prompts the user for a boolean value. If the user provides an empty string, the default value is returned.
 func promptForBool(prompt, explain string, defaultValue bool) bool {
-	var input string
+	if explain != "" {
+		fmt.Printf("%s\n\n", explain)
+	}
 
-	defaultStr := "N"
+	defaultStr := "[y/N]"
 
 	if defaultValue {
-		defaultStr = "y"
+		defaultStr = "[Y/n]"
 	}
 
-	fmt.Printf("%s\n\n", prompt)
+	fmt.Printf("%s %s: ", prompt, defaultStr)
 
-	if explain != "" {
-		fmt.Printf("%s\n", explain)
-	}
-
-	fmt.Printf("\nDefault: %s\n\n", defaultStr)
-
-	fmt.Scanln(&input)
+	input := strings.ToLower(readLine())
 	fmt.Println()
-
-	input = strings.ToLower(strings.TrimSpace(input))
 
 	if input == "y" {
 		return true
+	}
+
+	if input == "n" {
+		return false
 	}
 
 	return defaultValue


### PR DESCRIPTION
## Summary

- Add automations system: run custom scripts after encoding with parameters sourced from run data, user prompts, or static values
- Scripts receive parameters as `HMKV_PARAM_*` environment variables; controlled exclusively via `-a` flag
- Automations are managed via subcommands (`create`, `show`, `delete`, `list`) and stored as JSON in the OS config directory
- Execution outcomes (exit codes) recorded in run manifests and visible in `handymkv history`
- Refactor CLI subcommands (`config`, `discs`) and migrate all input from `fmt.Scanln` to a buffered `readLine()`

## Bug fixes

- Fix `promptForBool` not respecting explicit `"n"` when default is `true`
- Fix `prependDiscToSub` mutation lost due to range-copy loop iteration
- Validate automation names against path traversal (`/`, `\`, `..`)
- Validate empty `command` field in automation JSON at load time
- Warn on malformed automation files instead of silently skipping
- Deduplicate automation names from `-a` flag
- Record manifest entry after execution so exit code is captured
- Remove dead `_ = manifestPath` assignment
- Guard `deleteRawFiles` against directories moved by automations

## Other

- Strip debug symbols from release builds (`-s -w` ldflags)
- Update `move-media` example script to strip `_t##` MakeMKV artifact from filenames
- Update README with automations documentation and corrected command references