### PR TITLE
fix: Correct multiple typos across the codebase

### DIFF
--- a/cmd/handymkv/doc.go
+++ b/cmd/handymkv/doc.go
@@ -9,7 +9,7 @@ The main package is responsible for parsing command line arguments and executing
 
 The main function is the entry point for the application. It parses command line arguments and then executes the application.
 
-## Prequisite Checking
+## Prerequisite Checking
 
 The checkForPrerequisites function is called to ensure that the application has all the prerequisites applications installed it needs to run.
 
@@ -26,9 +26,9 @@ If the -c flag is provided then the application will run the setup process. This
 
 If the -d flag is provided then the application will rip the disc with the specified index. If no index is provided then the application will rip disc 0.
 
-If the -q flag is provided then the application will rip the disc with the specified quality. If no quality is provided then the application will rip with the quality specificed in the config file.
+If the -q flag is provided then the application will rip the disc with the specified quality. If no quality is provided then the application will rip with the quality specified in the config file.
 
-If the -e flag is provided then the application will rip the disc with the specified encoder. If no encoder is provided then the application will rip with the encoder specificed in the config file.
+If the -e flag is provided then the application will rip the disc with the specified encoder. If no encoder is provided then the application will rip with the encoder specified in the config file.
 
 If the -v flag is provided then the application will print the version of the application and exit.
 

--- a/cmd/handymkv/main.go
+++ b/cmd/handymkv/main.go
@@ -286,8 +286,8 @@ func main() {
 		// If the error is an ExternalProcessError, print the process output
 		expErr, isExternalProcessErr := err.(*hmkv.ExternalProcessError)
 
-		if isExternalProcessErr && expErr.ProcessOuput != "" {
-			fmt.Print(expErr.ProcessOuput)
+		if isExternalProcessErr && expErr.ProcessOutput != "" {
+			fmt.Print(expErr.ProcessOutput)
 		}
 	}
 }

--- a/internal/hmkv/conf.go
+++ b/internal/hmkv/conf.go
@@ -300,7 +300,7 @@ func promptForConfig(hb *HandBrakeCLI, configLocationSelection int) (*handyMKVCo
 		config.EncodeConfig.Encoder = promptForSelection("What encoder should be used by default?", encoderOptions)
 		clear()
 
-		// Make the user choose beteween providing a numeric quality and an encoder preset for quality
+		// Make the user choose between providing a numeric quality and an encoder preset for quality
 		var qualitySelection int
 
 		fmt.Printf("You can provide an encoder preset for quality or a numeric quality value. Numeric values are only recommended if you are familiar with the encoder. Please choose one of the two following options:\n\n")

--- a/internal/hmkv/constants.go
+++ b/internal/hmkv/constants.go
@@ -46,13 +46,13 @@ var ErrTitlesDiscRead = errors.New("cannot read titles from disc")
 
 type ExternalProcessError struct {
 	Err          error
-	ProcessOuput string
+	ProcessOutput string
 }
 
 func NewExternalProcessError(err error, output string) *ExternalProcessError {
 	return &ExternalProcessError{
 		Err:          err,
-		ProcessOuput: output,
+		ProcessOutput: output,
 	}
 }
 

--- a/internal/hmkv/doc.go
+++ b/internal/hmkv/doc.go
@@ -1,7 +1,7 @@
 package hmkv
 
 /*
-package hmkv provides provides the bulk of the functionality for the Handy application.
+package hmkv provides the bulk of the functionality for the Handy application.
 
 # Overview
 

--- a/internal/hmkv/mkv.go
+++ b/internal/hmkv/mkv.go
@@ -124,7 +124,7 @@ func (mkv *MakeMKV) ripTitle(ctx context.Context, title *TitleInfo, destDir stri
 		f, openLogFileErr := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 		if openLogFileErr != nil {
-			return fmt.Errorf("ripping title from disc was not successful - %w - an error occured while creating log file - %w", err, openLogFileErr)
+			return fmt.Errorf("ripping title from disc was not successful - %w - an error occurred while creating log file - %w", err, openLogFileErr)
 		}
 
 		defer f.Close()


### PR DESCRIPTION
## Summary
This PR fixes multiple typos found throughout the codebase:

## Changes
- `ProcessOuput` → `ProcessOutput` in `constants.go` and `main.go`
- `occured` → `occurred` in `mkv.go`
- `beteween` → `between` in `conf.go`
- `provides provides` → `provides` in `internal/hmkv/doc.go`
- `Prequisite` → `Prerequisite` in `cmd/handymkv/doc.go`
- `specificed` → `specified` in `cmd/handymkv/doc.go` (2 occurrences)

## Test plan
- [ ] Typo fixes only, no functional changes
- [ ] Code compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)