### PR TITLE
fix: Correct redundant error handling logic

### DIFF
--- a/internal/hmkv/mkv.go
+++ b/internal/hmkv/mkv.go
@@ -70,8 +70,8 @@ func GetMakeMKVExecutable() (string, error) {
 
 		_, err := os.Stat(winExecutable)
 
-		// make sure that the file exists
-		if os.IsNotExist(err) || err != nil {
+		// make sure that the file exists and is accessible
+		if err != nil {
 			return "", fmt.Errorf("makemkvcon executable not found at %s", winExecutable)
 		}
 


### PR DESCRIPTION
## Summary
Fix redundant error handling logic in `GetMakeMKVExecutable()` function.

## Problem
The condition `os.IsNotExist(err) || err != nil` in `internal/hmkv/mkv.go:74` is redundant:
- `os.IsNotExist(err)` returns false when err is nil
- The `|| err != nil` part makes the entire condition true for any non-nil error

## Solution
Simplified to just `err != nil`, which is the correct check:
- If err is nil, the file exists and we return the executable path
- If err is non-nil (for any reason), we return an error

## Test plan
- [ ] Logic change only, no functional change in behavior
- [ ] Code compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)