### PR TITLE
Allow extra HandBrakeCLI arguments via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,33 @@ All output files will be stored in the directory specified in the configuration 
 
 Note: If there is a `config.json` file in the working directory at execution time, that file will be used instead of the user-wide configuration file.
 
+## Extra HandBrake Arguments
+
+Some things cannot be expressed in a HandBrake preset. A preset can only select audio tracks by language and by "first" or "all", so it cannot pick individual tracks by index, and it applies a single audio rule to every track it selects. A disc that carries several tracks in the same language therefore cannot be handled by a preset alone.
+
+The optional `extra_handbrake_args` setting appends arbitrary arguments to the HandBrakeCLI invocation. It is not written by the configuration wizard and must be added to `config.json` by hand:
+
+```json
+{
+  "encoding_params": {
+    "preset_file": "/path/to/preset.json",
+    "handbrake_preset": "MyPreset",
+    "extra_handbrake_args": [
+      "-a", "1,2",
+      "-E", "ca_aac,ca_aac",
+      "-B", "160,640",
+      "--mixdown", "mono,5point1"
+    ]
+  }
+}
+```
+
+The arguments are appended after the preset. HandBrakeCLI applies an imported preset first and lets later flags override it, so the preset can continue to govern video while these arguments take over audio track selection. The example above encodes only source tracks 1 and 2, the first as mono and the second as 5.1, ignoring any further tracks the disc may carry.
+
+Arguments that HandyMKV derives itself are rejected, because supplying them would redirect an encode away from the staged input or the configured output directory. These are `--input`, `-i`, `--output`, `-o`, `--preset` and `--preset-import-file`.
+
+Track indexes refer to the ripped MKV, not to the disc. They are only stable while every title shares the same stream layout, so verify the layout before relying on index based selection across a whole series.
+
 ## Run History
 
 After each run, HandyMKV writes a manifest file recording what was ripped and encoded, file sizes, durations, and whether raw MKV files were deleted. These manifests can be browsed at any time with the `history` subcommand.

--- a/internal/hmkv/conf.go
+++ b/internal/hmkv/conf.go
@@ -70,6 +70,10 @@ func (config *handyMKVConfig) String() string {
 		}
 	}
 
+	if len(config.EncodeConfig.ExtraHandBrakeArgs) > 0 {
+		sb.WriteString(fmt.Sprintf("Extra HandBrake Arguments: %s\n", strings.Join(config.EncodeConfig.ExtraHandBrakeArgs, " ")))
+	}
+
 	sb.WriteString("\n")
 	sb.WriteString("General Settings\n\n")
 	fmt.Fprintf(&sb, "MKV Output Directory: %s\n", config.MKVOutputDirectory)
@@ -151,6 +155,10 @@ func readConfigFile(filePath string) (*handyMKVConfig, error) {
 
 	if err != nil {
 		return nil, fmt.Errorf("error parsing config file - %w", err)
+	}
+
+	if err := validateExtraHandBrakeArgs(cfg.EncodeConfig.ExtraHandBrakeArgs); err != nil {
+		return nil, fmt.Errorf("error validating config file - %w", err)
 	}
 
 	if cfg.EncodeConfig.PresetFile != "" {

--- a/internal/hmkv/hb.go
+++ b/internal/hmkv/hb.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -77,6 +78,7 @@ type EncodingParams struct {
 	OutputFileFormat            string   `json:"output_file_format,omitempty"`
 	Preset                      string   `json:"handbrake_preset,omitempty"`
 	PresetFile                  string   `json:"preset_file,omitempty"`
+	ExtraHandBrakeArgs          []string `json:"extra_handbrake_args,omitempty"`
 }
 
 type HandBrakePresetFile struct {
@@ -86,6 +88,37 @@ type HandBrakePresetFile struct {
 type HandBrakePreset struct {
 	PresetName string `json:"PresetName"`
 	FileFormat string `json:"FileFormat"`
+}
+
+// HandBrakeCLI flags that handymkv derives from the configuration and the disc
+// being processed. Supplying them as extra arguments would silently redirect an
+// encode away from the staged input or the configured output directory, so they
+// are rejected rather than merged.
+var reservedHandBrakeArgs []string = []string{
+	"--input",
+	"-i",
+	"--output",
+	"-o",
+	"--preset",
+	"--preset-import-file",
+}
+
+var ErrReservedHandBrakeArg = errors.New("reserved HandBrakeCLI argument")
+
+// Checks that extra HandBrakeCLI arguments do not collide with the ones handymkv
+// owns. Both the bare flag and its inline "--flag=value" form are rejected.
+func validateExtraHandBrakeArgs(args []string) error {
+	for _, arg := range args {
+		flag, _, _ := strings.Cut(arg, "=")
+
+		for _, reserved := range reservedHandBrakeArgs {
+			if flag == reserved {
+				return fmt.Errorf("%w - %s is set by handymkv and cannot be overridden", ErrReservedHandBrakeArg, reserved)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Builds the full HandBrakeCLI argument list for an encode.
@@ -126,6 +159,12 @@ func buildEncodeArgs(params *EncodingParams) []string {
 			}
 		}
 	}
+
+	// Extra arguments are appended last. HandBrakeCLI applies an imported preset
+	// first and lets later flags override it, so this is what allows a preset to
+	// govern video while the arguments below take over track selection, encoders
+	// or anything else the preset format cannot express.
+	args = append(args, params.ExtraHandBrakeArgs...)
 
 	return args
 }

--- a/internal/hmkv/hb.go
+++ b/internal/hmkv/hb.go
@@ -88,9 +88,8 @@ type HandBrakePreset struct {
 	FileFormat string `json:"FileFormat"`
 }
 
-func (hb *HandBrakeCLI) encode(ctx context.Context,
-	params *EncodingParams,
-	onProgress func(percent int)) error {
+// Builds the full HandBrakeCLI argument list for an encode.
+func buildEncodeArgs(params *EncodingParams) []string {
 	var args []string = []string{
 		"--input", params.MKVOutputPath,
 		"--output", params.HandBrakeOutputPath,
@@ -127,6 +126,14 @@ func (hb *HandBrakeCLI) encode(ctx context.Context,
 			}
 		}
 	}
+
+	return args
+}
+
+func (hb *HandBrakeCLI) encode(ctx context.Context,
+	params *EncodingParams,
+	onProgress func(percent int)) error {
+	args := buildEncodeArgs(params)
 
 	cmd := exec.CommandContext(ctx, hb.executable,
 		args...,

--- a/internal/hmkv/hb_test.go
+++ b/internal/hmkv/hb_test.go
@@ -1,0 +1,108 @@
+package hmkv
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildEncodeArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   EncodingParams
+		expected []string
+	}{
+		{
+			name: "custom preset file",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Preset:              "MyPreset",
+				PresetFile:          "preset.json",
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--preset-import-file", "preset.json",
+				"--preset", "MyPreset",
+			},
+		},
+		{
+			name: "built-in preset takes no import file",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Preset:              "Fast 1080p30",
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--preset", "Fast 1080p30",
+			},
+		},
+		{
+			name: "simplified settings with encoder preset",
+			params: EncodingParams{
+				MKVOutputPath:               "in.mkv",
+				HandBrakeOutputPath:         "out.mkv",
+				Encoder:                     "x265_10bit",
+				EncoderPreset:               "slow",
+				SubtitleLanguages:           []string{"eng", "jpn"},
+				IncludeAllRelevantSubtitles: true,
+				AudioLanguages:              []string{"eng"},
+				IncludeAllRelevantAudio:     true,
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--encoder", "x265_10bit",
+				"--encoder-preset", "slow",
+				"--subtitle-lang-list", "eng,jpn",
+				"--all-subtitles",
+				"--audio-lang-list", "eng",
+				"--all-audio",
+			},
+		},
+		{
+			name: "simplified settings fall back to numeric quality",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Encoder:             "x265",
+				Quality:             22,
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--encoder", "x265",
+				"--quality", "22",
+			},
+		},
+		{
+			name: "language lists are omitted when empty",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Encoder:             "x264",
+				Quality:             20,
+				SubtitleLanguages:   []string{},
+				AudioLanguages:      []string{},
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--encoder", "x264",
+				"--quality", "20",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := buildEncodeArgs(&test.params)
+
+			if !slices.Equal(actual, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/hmkv/hb_test.go
+++ b/internal/hmkv/hb_test.go
@@ -1,6 +1,7 @@
 package hmkv
 
 import (
+	"errors"
 	"slices"
 	"testing"
 )
@@ -94,6 +95,58 @@ func TestBuildEncodeArgs(t *testing.T) {
 				"--quality", "20",
 			},
 		},
+		{
+			// Extra arguments must come after --preset. HandBrakeCLI applies an
+			// imported preset first and lets later flags override it, so ordering
+			// is what makes the override work at all.
+			name: "extra arguments are appended after the preset",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Preset:              "MyPreset",
+				PresetFile:          "preset.json",
+				ExtraHandBrakeArgs:  []string{"-a", "1,2", "--mixdown", "mono,5point1"},
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--preset-import-file", "preset.json",
+				"--preset", "MyPreset",
+				"-a", "1,2",
+				"--mixdown", "mono,5point1",
+			},
+		},
+		{
+			name: "extra arguments also apply to simplified settings",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Encoder:             "x265",
+				Quality:             20,
+				ExtraHandBrakeArgs:  []string{"--audio-fallback", "ac3"},
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--encoder", "x265",
+				"--quality", "20",
+				"--audio-fallback", "ac3",
+			},
+		},
+		{
+			name: "no extra arguments leaves the argument list untouched",
+			params: EncodingParams{
+				MKVOutputPath:       "in.mkv",
+				HandBrakeOutputPath: "out.mkv",
+				Preset:              "MyPreset",
+				ExtraHandBrakeArgs:  []string{},
+			},
+			expected: []string{
+				"--input", "in.mkv",
+				"--output", "out.mkv",
+				"--preset", "MyPreset",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -102,6 +155,86 @@ func TestBuildEncodeArgs(t *testing.T) {
 
 			if !slices.Equal(actual, test.expected) {
 				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestValidateExtraHandBrakeArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name:      "nil arguments are valid",
+			args:      nil,
+			expectErr: false,
+		},
+		{
+			name:      "track selection and encoder overrides are allowed",
+			args:      []string{"-a", "1,2", "-E", "ca_aac,ca_aac", "-B", "160,640"},
+			expectErr: false,
+		},
+		{
+			// The check does not track which tokens are flags and which are values,
+			// so a value that happens to equal a reserved flag is rejected too. That
+			// is deliberate: no HandBrakeCLI option takes "-i" or "--output" as its
+			// value, and refusing loudly beats silently redirecting an encode.
+			name:      "a reserved flag is rejected even in value position",
+			args:      []string{"--mixdown", "mono", "--encoder-preset", "-i"},
+			expectErr: true,
+		},
+		{
+			name:      "--output is reserved",
+			args:      []string{"--output", "/tmp/elsewhere.mkv"},
+			expectErr: true,
+		},
+		{
+			name:      "-o is reserved",
+			args:      []string{"-o", "/tmp/elsewhere.mkv"},
+			expectErr: true,
+		},
+		{
+			name:      "--input is reserved",
+			args:      []string{"--input", "/tmp/other.mkv"},
+			expectErr: true,
+		},
+		{
+			name:      "--preset is reserved",
+			args:      []string{"--preset", "Fast 1080p30"},
+			expectErr: true,
+		},
+		{
+			name:      "--preset-import-file is reserved",
+			args:      []string{"--preset-import-file", "other.json"},
+			expectErr: true,
+		},
+		{
+			name:      "a reserved flag in inline form is reserved",
+			args:      []string{"--output=/tmp/elsewhere.mkv"},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateExtraHandBrakeArgs(test.args)
+
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+
+				if !errors.Is(err, ErrReservedHandBrakeArg) {
+					t.Errorf("expected ErrReservedHandBrakeArg, got %v", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
 			}
 		})
 	}

--- a/internal/hmkv/hmkv.go
+++ b/internal/hmkv/hmkv.go
@@ -425,23 +425,31 @@ func ripTitles(
 
 		hbOutputDir := filepath.Join(config.HBOutputDirectory, title.Subdirectory())
 
-		encChannel <- EncodingParams{
-			TitleIndex:          title.Index,
-			DiscId:              title.DiscId,
-			MKVOutputPath:       mkvOutputPath,
-			HandBrakeOutputPath: filepath.Join(hbOutputDir, encodingOutputFileName),
-			RippedFileSizeBytes: rippedSizeBytes,
-			RippingDuration:     ripDuration.String(),
-			Quality:             config.EncodeConfig.Quality,
-			Encoder:             config.EncodeConfig.Encoder,
-			EncoderPreset:       config.EncodeConfig.EncoderPreset,
-			OutputFileFormat:    config.EncodeConfig.OutputFileFormat,
-			Preset:              config.EncodeConfig.Preset,
-			PresetFile:          config.EncodeConfig.PresetFile,
-			SubtitleLanguages:   config.EncodeConfig.SubtitleLanguages,
-			AudioLanguages:      config.EncodeConfig.AudioLanguages,
-		}
+		encChannel <- newEncodingParams(config, &title, mkvOutputPath,
+			filepath.Join(hbOutputDir, encodingOutputFileName), rippedSizeBytes, ripDuration)
 	}
+}
+
+// Builds the parameters for a single title's encode. The configured encode
+// settings are carried over wholesale, so a setting added to EncodingParams is
+// passed to HandBrake without needing to be listed here as well. Only the
+// per-title fields, which have no configured counterpart, are filled in.
+func newEncodingParams(config *handyMKVConfig,
+	title *TitleInfo,
+	mkvOutputPath string,
+	handBrakeOutputPath string,
+	rippedSizeBytes int64,
+	ripDuration time.Duration) EncodingParams {
+	params := config.EncodeConfig
+
+	params.TitleIndex = title.Index
+	params.DiscId = title.DiscId
+	params.MKVOutputPath = mkvOutputPath
+	params.HandBrakeOutputPath = handBrakeOutputPath
+	params.RippedFileSizeBytes = rippedSizeBytes
+	params.RippingDuration = ripDuration.String()
+
+	return params
 }
 
 // Prompts the user to create a configuration file.

--- a/internal/hmkv/hmkv_test.go
+++ b/internal/hmkv/hmkv_test.go
@@ -1,0 +1,117 @@
+package hmkv
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+// Guards the config-to-encode handoff. The encode parameters used to be
+// assembled field by field, so a setting could be read from the config, shown
+// by the config subcommand, and still never reach HandBrakeCLI.
+func TestNewEncodingParamsCarriesConfiguredSettings(t *testing.T) {
+	config := &handyMKVConfig{
+		EncodeConfig: EncodingParams{
+			Encoder:                     "x265_10bit",
+			EncoderPreset:               "slow",
+			Quality:                     22,
+			SubtitleLanguages:           []string{"eng"},
+			IncludeAllRelevantSubtitles: true,
+			AudioLanguages:              []string{"eng", "jpn"},
+			IncludeAllRelevantAudio:     true,
+			OutputFileFormat:            "mkv",
+			Preset:                      "MyPreset",
+			PresetFile:                  "preset.json",
+			ExtraHandBrakeArgs:          []string{"-a", "1,2", "--mixdown", "stereo,5point1"},
+		},
+	}
+
+	title := &TitleInfo{Index: 3, DiscId: 1}
+
+	params := newEncodingParams(config, title, "in.mkv", "out.mkv", 1234, 90*time.Second)
+
+	if params.Encoder != "x265_10bit" {
+		t.Errorf("expected encoder x265_10bit, got %q", params.Encoder)
+	}
+
+	if params.EncoderPreset != "slow" {
+		t.Errorf("expected encoder preset slow, got %q", params.EncoderPreset)
+	}
+
+	if params.Quality != 22 {
+		t.Errorf("expected quality 22, got %d", params.Quality)
+	}
+
+	if params.Preset != "MyPreset" || params.PresetFile != "preset.json" {
+		t.Errorf("expected preset MyPreset from preset.json, got %q from %q", params.Preset, params.PresetFile)
+	}
+
+	if params.OutputFileFormat != "mkv" {
+		t.Errorf("expected output file format mkv, got %q", params.OutputFileFormat)
+	}
+
+	if !slices.Equal(params.AudioLanguages, []string{"eng", "jpn"}) {
+		t.Errorf("expected audio languages [eng jpn], got %v", params.AudioLanguages)
+	}
+
+	if !slices.Equal(params.SubtitleLanguages, []string{"eng"}) {
+		t.Errorf("expected subtitle languages [eng], got %v", params.SubtitleLanguages)
+	}
+
+	if !params.IncludeAllRelevantAudio {
+		t.Error("expected IncludeAllRelevantAudio to be carried over")
+	}
+
+	if !params.IncludeAllRelevantSubtitles {
+		t.Error("expected IncludeAllRelevantSubtitles to be carried over")
+	}
+
+	if !slices.Equal(params.ExtraHandBrakeArgs, []string{"-a", "1,2", "--mixdown", "stereo,5point1"}) {
+		t.Errorf("expected extra HandBrake arguments to be carried over, got %v", params.ExtraHandBrakeArgs)
+	}
+
+	// The per-title fields have no configured counterpart and must be filled in.
+	if params.TitleIndex != 3 || params.DiscId != 1 {
+		t.Errorf("expected title 3 of disc 1, got title %d of disc %d", params.TitleIndex, params.DiscId)
+	}
+
+	if params.MKVOutputPath != "in.mkv" || params.HandBrakeOutputPath != "out.mkv" {
+		t.Errorf("expected in.mkv -> out.mkv, got %q -> %q", params.MKVOutputPath, params.HandBrakeOutputPath)
+	}
+
+	if params.RippedFileSizeBytes != 1234 {
+		t.Errorf("expected ripped size 1234, got %d", params.RippedFileSizeBytes)
+	}
+
+	if params.RippingDuration != "1m30s" {
+		t.Errorf("expected ripping duration 1m30s, got %q", params.RippingDuration)
+	}
+}
+
+// The settings a user configures must survive all the way into the arguments
+// HandBrakeCLI is actually invoked with.
+func TestConfiguredExtraArgsReachHandBrake(t *testing.T) {
+	config := &handyMKVConfig{
+		EncodeConfig: EncodingParams{
+			Preset:             "MyPreset",
+			PresetFile:         "preset.json",
+			ExtraHandBrakeArgs: []string{"-a", "1,2"},
+		},
+	}
+
+	params := newEncodingParams(config, &TitleInfo{}, "in.mkv", "out.mkv", 0, 0)
+
+	args := buildEncodeArgs(&params)
+
+	expected := []string{
+		"--input", "in.mkv",
+		"--output", "out.mkv",
+		"--preset-import-file", "preset.json",
+		"--preset", "MyPreset",
+		"-a", "1,2",
+	}
+
+	if !slices.Equal(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}


### PR DESCRIPTION
With a custom preset configured, HandyMKV runs HandBrakeCLI with only `--input`, `--output`, `--preset-import-file` and `--preset`. Everything else has to come from the preset, and some things simply cannot.

A preset picks audio tracks by language only, as either "first" or "all". It cannot pick a track by index, and it applies one audio rule to every track it selects. So a disc with several tracks in the same language leaves you choosing between dropping tracks you want and keeping ones you don't.

I hit this on a Blu-ray with three English tracks: an LPCM mono original, a DTS-HD MA 5.1 remix, and the lossy DTS core of that same remix. "first" silently threw away the 5.1. "all" kept the redundant core and forced one bitrate onto both a 2-channel and a 6-channel track.

A new optional `extra_handbrake_args` setting:

```json
"encoding_params": {
  "preset_file": "/path/to/preset.json",
  "handbrake_preset": "MyPreset",
  "extra_handbrake_args": [
    "-a", "1,2",
    "-E", "ca_aac,ca_aac",
    "-B", "160,640",
    "--mixdown", "stereo,5point1"
  ]
}
```

The arguments go after the preset, so HandBrakeCLI's own override rules apply: the preset still governs video, while these take over audio. The example keeps source tracks 1 and 2 at 160 and 640 kb/s and ignores the rest.

Arguments HandyMKV sets itself are rejected at config load rather than merged: `--input`, `-i`, `--output`, `-o`, `--preset`, `--preset-import-file`. Letting a config override those would quietly redirect an encode away from the staged input or the configured output directory.

The wizard does not prompt for the setting, since `promptForStringSlice` splits on commas and values like `-a 1,2` contain them. It has to be added to `config.json` by hand.

Track indexes refer to the ripped MKV, not the disc, and only hold while every title shares a stream layout. Noted in the README.
